### PR TITLE
Supply initial CSV values

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -14,7 +14,9 @@ class User extends Entity implements HasGroup, HasPermission
         'deleted_at',
     ];
     protected $attributes = [
-        'id' => null,
+        'id'          => null,
+        'groups'      => '',
+        'permissions' => '',
     ];
     protected $casts = [
         'groups'      => 'csv',


### PR DESCRIPTION
Fixes an issue for PHP 8.1+ where uninitiated CSV values would cause deprecated calls: `explode(',', null)`